### PR TITLE
feat: Add delete functionality for songs and parts

### DIFF
--- a/src/components/CallTable.js
+++ b/src/components/CallTable.js
@@ -3,10 +3,8 @@ import './CallTable.css';
 import { SongContext } from '../contexts/SongContext';
 
 function CallTable() {
-  const { songs, handleCallChange, presets } = useContext(SongContext);
+  const { songs, handleCallChange, presets, deleteSong, deletePart } = useContext(SongContext);
 
-  // Determine the column headers from the parts of the first song.
-  // This assumes all songs have the same parts structure.
   const parts = songs.length > 0 ? Object.keys(songs[0].calls) : [];
 
   return (
@@ -15,8 +13,12 @@ function CallTable() {
         <tr>
           <th>Song</th>
           {parts.map(part => (
-            <th key={part}>{part}</th>
+            <th key={part}>
+              {part}
+              <button onClick={() => deletePart(part)} style={{marginLeft: '5px', cursor: 'pointer', padding: '2px 5px'}}>x</button>
+            </th>
           ))}
+          <th>Actions</th>
         </tr>
       </thead>
       <tbody>
@@ -40,6 +42,9 @@ function CallTable() {
                 ))}
               </td>
             ))}
+            <td>
+              <button onClick={() => deleteSong(song.name)}>削除</button>
+            </td>
           </tr>
         ))}
       </tbody>

--- a/src/hooks/useSongs.js
+++ b/src/hooks/useSongs.js
@@ -75,6 +75,23 @@ export const useSongs = () => {
     setSongs(updatedSongs);
   };
 
+  const deleteSong = (songName) => {
+    if (window.confirm(`本当にこの曲「${songName}」を削除しますか？`)) {
+      setSongs(songs.filter(song => song.name !== songName));
+    }
+  };
+
+  const deletePart = (partName) => {
+    if (window.confirm(`本当にこのパート「${partName}」を削除しますか？`)) {
+      const updatedSongs = songs.map(song => {
+        const newCalls = { ...song.calls };
+        delete newCalls[partName];
+        return { ...song, calls: newCalls };
+      });
+      setSongs(updatedSongs);
+    }
+  };
+
   return {
     songs,
     isAddingPart,
@@ -84,5 +101,7 @@ export const useSongs = () => {
     addSong,
     addPart,
     handleCallChange,
+    deleteSong,
+    deletePart,
   };
 };


### PR DESCRIPTION
Implements `deleteSong` and `deletePart` functions in the useSongs hook, with `window.confirm` for safety. Adds a delete button for each song row and for each part column in the CallTable. This allows users to safely remove unwanted songs or parts from the chart.